### PR TITLE
版本管理交互化：版本号唯一来源改为 versioninfo.json

### DIFF
--- a/bump-version.ps1
+++ b/bump-version.ps1
@@ -1,0 +1,67 @@
+# 7zrpw version helper.
+# Single source of version = client\versioninfo.json. This script reads the current
+# version, asks whether to update, validates the format, and writes the new version
+# back to ALL version fields in versioninfo.json (numeric parts + string parts).
+# Called by build.bat; also supports -NewVersion for non-interactive use (tests/CI).
+# NOTE: keep this file ASCII only -- a no-BOM .ps1 with non-ASCII chars is misparsed
+# by Windows PowerShell 5.1 under a non-UTF8 system codepage.
+param(
+    [string]$Path = (Join-Path $PSScriptRoot 'client\versioninfo.json'),
+    [string]$NewVersion
+)
+$ErrorActionPreference = 'Stop'
+
+function Test-VerFormat([string]$v) {
+    return $v -match '^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'
+}
+
+# Write version back into versioninfo.json via in-place regex replace, preserving the
+# rest of the JSON structure and writing UTF-8 without BOM.
+function Set-Version([string]$p, [string]$v) {
+    $raw = Get-Content $p -Raw -Encoding UTF8
+    $n = $v.TrimStart('v').Split('.')
+    $bld = if ($n.Count -ge 4) { [int]$n[3] } else { 0 }
+    $num = '"Major":' + [int]$n[0] + ',"Minor":' + [int]$n[1] + ',"Patch":' + [int]$n[2] + ',"Build":' + $bld
+    $raw = $raw -replace '"Major":\d+,"Minor":\d+,"Patch":\d+,"Build":\d+', $num
+    $raw = $raw -replace '("FileVersion":")v[^"]*"', ('${1}' + $v + '"')
+    $raw = $raw -replace '("ProductVersion":")v[^"]*"', ('${1}' + $v + '"')
+    [System.IO.File]::WriteAllText($p, $raw, (New-Object System.Text.UTF8Encoding($false)))
+}
+
+$raw = Get-Content $Path -Raw -Encoding UTF8
+$cur = ([regex]'"FileVersion":"(v[^"]*)"').Match($raw).Groups[1].Value
+
+# Non-interactive: apply directly (validate then write).
+if ($NewVersion) {
+    $NewVersion = $NewVersion.Trim()
+    if (-not (Test-VerFormat $NewVersion)) {
+        Write-Host "[ERROR] Invalid version format: $NewVersion (expect vX.Y.Z or vX.Y.Z.W)"
+        exit 1
+    }
+    Set-Version $Path $NewVersion
+    Write-Host "Version updated: $cur -> $NewVersion"
+    exit 0
+}
+
+# Interactive mode.
+Write-Host "============================================"
+Write-Host " Current version: $cur"
+Write-Host "============================================"
+$ans = Read-Host " Update version? (Y/N) [N]"
+if ($ans -notmatch '^(y|yes)$') {
+    Write-Host "Keep current version: $cur"
+    exit 0
+}
+while ($true) {
+    $new = Read-Host " Enter new version (vX.Y.Z or vX.Y.Z.W, e.g. v0.1.6.1)"
+    if ([string]::IsNullOrWhiteSpace($new)) {
+        Write-Host "No input, keep current version: $cur"
+        exit 0
+    }
+    $new = $new.Trim()
+    if (Test-VerFormat $new) { break }
+    Write-Host "[ERROR] Invalid format, expect vX.Y.Z or vX.Y.Z.W (digits). Try again."
+}
+Set-Version $Path $new
+Write-Host "Version updated: $cur -> $new (versioninfo.json synced)"
+exit 0

--- a/client/main.go
+++ b/client/main.go
@@ -10,8 +10,11 @@ import (
 // 添加调试开关
 var debugMode bool = false
 
-// 程序版本号（同时决定 7z 释放目录、旧目录清理逻辑，见 sevenzip.go）
-const VERSION = "v0.1.6.0"
+// VERSION 程序版本号。由 build.bat 通过 -ldflags "-X main.VERSION=%VER%" 在构建时注入，
+// 发版只改 build.bat 的 VER 一处；直接 go build 未注入时为 "dev"（非正式构建标记）。
+// 它同时决定界面显示、7z 释放目录(7zrpw_<VERSION>)、自动更新的版本比对，故须保持 vX.Y.Z 格式。
+// 注意：-X 只能注入 var 不能注入 const，所以这里必须是 var。
+var VERSION = "dev"
 
 // 主函数
 func main() {


### PR DESCRIPTION
## 改动
- `client/main.go`: `VERSION` 由 `const` 改为 `var`（默认 `"dev"`），改由 build.bat 的 `-ldflags -X main.VERSION` 注入，源码不再写死版本号
- 新增 `bump-version.ps1`: 运行 build.bat 时交互读取/更新版本号，校验格式（`vX.Y.Z[.W]`）后同步写回 `client/versioninfo.json` 全部版本字段（数字段+字符串段）

## 说明
- 版本号唯一来源 = `client/versioninfo.json`；发版时跑 build.bat 按提示输入即可
- `build.bat` 含密钥不入仓，其改动仅本地
- `bump-version.ps1` 保持 ASCII，规避 PowerShell 5.1 对无 BOM .ps1 的码页误解析

## 测试
- bump-version.ps1：读/写/校验/交互、3-4 段、非法与注入串拒绝、编码无 BOM、中文保留 —— 均用真实 PowerShell/cmd 实测
- `-X main.VERSION` 注入与 `go build ./...` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)